### PR TITLE
Fix/conda lookup

### DIFF
--- a/workflow/envs/env.yml
+++ b/workflow/envs/env.yml
@@ -26,4 +26,5 @@ dependencies:
     - seaborn
     - pydeseq2=0.4.4
     - anndata>=0.8.0
+    - ensureconda
 

--- a/workflow/rules/utils.smk
+++ b/workflow/rules/utils.smk
@@ -4,11 +4,11 @@ import re
 rule dump_versions:
     output:
         ver = "versions.txt"
-    #TODO: check whether code can be reverted to use workflow.source_path
-    #conda: workflow.source_path("envs/env.yml")
     conda: "../envs/env.yml"
+    # we are using 'ensureconda' because we are unsure which
+    # conda flavour is prefered by the user
     shell:"""
-    $MAMBA_EXE list > {output.ver} 
+    eval $(ensureconda) list > {output.ver} 
     """
 
 rule info: ## print pipeline information


### PR DESCRIPTION
the rule `dump_versions` was broken, because the env variable `MAMBA_EXE` does not exist in every environment.

Now, `ensureconda` was introduced in the environment and in the rule to look up the conda flavour a user has installed. This is used to dump the software versions.