### PR TITLE
feat: map qc

### DIFF
--- a/workflow/Snakefile
+++ b/workflow/Snakefile
@@ -42,6 +42,7 @@ rule all:
         de_heatmap="de_analysis/heatmap.svg",
         lfc_analysis="de_analysis/lfc_analysis.csv",
         samstats=expand("QC/samstats/{sample}.txt", sample=samples["sample"]),
+        map_qc=directory("QC/qualimap/{sample}")
 
 
 rule genome_to_transcriptome:

--- a/workflow/Snakefile
+++ b/workflow/Snakefile
@@ -42,7 +42,7 @@ rule all:
         de_heatmap="de_analysis/heatmap.svg",
         lfc_analysis="de_analysis/lfc_analysis.csv",
         samstats=expand("QC/samstats/{sample}.txt", sample=samples["sample"]),
-        map_qc=directory("QC/qualimap/{sample}")
+        map_qc=expand("QC/qualimap/{sample}.tar.gz", sample=samples["sample"]),
 
 
 rule genome_to_transcriptome:
@@ -101,13 +101,13 @@ rule map_reads:
     """
 
 
-rule sam_sort:
+rule sam_view:
     input:
         sam=rules.map_reads.output,
     output:
         "sorted_alignments/{sample}.bam",
     log:
-        "logs/samtools/samsort_{sample}.log",
+        "logs/samtools/samview_{sample}.log",
     conda:
         "envs/env.yml"
     shell:
@@ -116,7 +116,7 @@ rule sam_sort:
 
 rule sam_index:
     input:
-        sbam=rules.sam_sort.output,
+        sbam=rules.sam_view.output,
     output:
         ibam="sorted_alignments/{sample}_index.bam",
     log:
@@ -130,24 +130,9 @@ rule sam_index:
         """
 
 
-rule sam_stats:
-    input:
-        bam=rules.sam_sort.output,
-    output:
-        "QC/samstats/{sample}.txt",
-    log:
-        "logs/samtools/samstats_{sample}.log",
-    conda:
-        "envs/env.yml"
-    shell:
-        """
-            samtools stats -@ {resources.cpus_per_task} {input.bam} > {output} 2> {log}
-        """
-
-
 rule count_reads:
     input:
-        bam=rules.sam_sort.output,
+        bam=rules.sam_view.output,
         trs=rules.genome_to_transcriptome.output,
     output:
         tsv="counts/{sample}_salmon/quant.sf",

--- a/workflow/envs/env.yml
+++ b/workflow/envs/env.yml
@@ -28,4 +28,5 @@ dependencies:
     - anndata>=0.8.0
     - ensureconda
     - gffread>=0.12.7
+    - qualimap>=2.3
 

--- a/workflow/envs/env.yml
+++ b/workflow/envs/env.yml
@@ -29,4 +29,4 @@ dependencies:
     - ensureconda
     - gffread>=0.12.7
     - qualimap>=2.3
-
+    - snakemake-wrapper-utils>=0.6.2

--- a/workflow/profile/config.yaml
+++ b/workflow/profile/config.yaml
@@ -29,7 +29,17 @@ set-resources:
         mem_mb_per_cpu: 1800
         runtime: "2h"
 
+    qualimap:
+        cpus_per_task: 8
+        mem_mb_per_cpu: 1800
+        runtime: "1h"
+
     sam_sort:
+        cpus_per_task: 4
+        mem_mb_per_cpu: 1800
+        runtime: "2h"
+
+    sam_view:
         cpus_per_task: 1
         mem_mb_per_cpu: 1800
         runtime: "1h"

--- a/workflow/profile/config.yaml
+++ b/workflow/profile/config.yaml
@@ -29,7 +29,7 @@ set-resources:
         mem_mb_per_cpu: 1800
         runtime: "2h"
 
-    qualimap:
+    map_qc:
         cpus_per_task: 8
         mem_mb_per_cpu: 1800
         runtime: "1h"

--- a/workflow/rules/qc.smk
+++ b/workflow/rules/qc.smk
@@ -4,6 +4,7 @@ import os
 localrules:
     compress_nplot,
     compress_nplot_all,
+    compress_map_qc,
 
 
 configfile: "config/config.yml"
@@ -129,11 +130,24 @@ rule map_qc:
     output:
         directory("QC/qualimap/{sample}"),
     log:
-        "logs/qualimap/{sample}",
+        "logs/qualimap/{sample}.log",
     conda:
         "../envs/env.yml"
     wrapper:
         "v3.12.1/bio/qualimap/bamqc"
+
+
+rule compress_map_qc:
+    input:
+        map_qc=rules.map_qc.output,
+    output:
+        "QC/qualimap/{sample}.tar.gz",
+    log:
+        "logs/qualimap/compress_{sample}.log",
+    conda:
+        None
+    shell:
+        "tar zcvf {output} {input} &> {log}"
 
 
 rule sam_stats:

--- a/workflow/rules/qc.smk
+++ b/workflow/rules/qc.smk
@@ -9,7 +9,7 @@ localrules:
 configfile: "config/config.yml"
 
 
-inputdir = config["inputdir"] #"/lustre/project/m2_zdvhpc/transcriptome_data/"
+inputdir = config["inputdir"]  # "/lustre/project/m2_zdvhpc/transcriptome_data/"
 
 
 # QC and metadata with NanoPlot
@@ -112,14 +112,14 @@ else:
 
 rule sam_sort:
     input:
-        sam="alignments/{sample}.sam"
+        sam="alignments/{sample}.sam",
     output:
-        "sorted_alignments/{sample}.bam"
-    log: 
-        "logs/samtools/samsort_{sample}.log"
-    conda: 
+        "sorted_alignments/{sample}_sorted.bam",
+    log:
+        "logs/samtools/samsort_{sample}.log",
+    conda:
         "../envs/env.yml"
-    shell: 
+    shell:
         "samtools sort -@ {resources.cpus_per_task} {input.sam} -o {output} -O bam &> {log}"
 
 
@@ -127,9 +127,9 @@ rule map_qc:
     input:
         sorted_bam=rules.sam_sort.output,
     output:
-        directory("QC/qualimap/{sample}")
+        directory("QC/qualimap/{sample}"),
     log:
-        "logs/qualimap/{sample}"
+        "logs/qualimap/{sample}",
     conda:
         "../envs/env.yml"
     wrapper:
@@ -149,4 +149,3 @@ rule sam_stats:
         """
             samtools stats -@ {resources.cpus_per_task} {input.bam} > {output} 2> {log}
         """
-


### PR DESCRIPTION
Added rules for assessing alignment quality using qualimap.
Moved the sam_stats qc rule from Snakefile to rules/qc.smk.
Renamed sam_sort rule to sam_view because salmon needs unsorted BAM files, but qualimap needs sorted BAM files, so a new sam_sort rule has been introduced in rules/qc.smk.