### PR TITLE
fix: write de params

### DIFF
--- a/workflow/rules/commons.smk
+++ b/workflow/rules/commons.smk
@@ -67,7 +67,6 @@ def rule_all_input():
         expand("counts/{sample}_salmon/quant.sf", sample=samples["sample"])
     )
     all_input.append("merged/all_counts.tsv")
-    all_input.append("de_analysis/de_params.tsv")
     all_input.append("de_analysis/dispersion_graph.svg")
     all_input.append("de_analysis/ma_graph.svg")
     all_input.append("de_analysis/heatmap.svg")

--- a/workflow/rules/diffexp.smk
+++ b/workflow/rules/diffexp.smk
@@ -1,9 +1,10 @@
 localrules:
     de_analysis,
 
+
 rule de_analysis:
     input:
-        all_counts=expand("counts/{sample}_salmon/quant.sf", sample=samples["sample"]),
+        all_counts=rules.merge_counts.output,
     output:
         dispersion_graph="de_analysis/dispersion_graph.svg",
         ma_graph="de_analysis/ma_graph.svg",

--- a/workflow/rules/diffexp.smk
+++ b/workflow/rules/diffexp.smk
@@ -1,22 +1,8 @@
 localrules:
-    write_de_params,
     de_analysis,
-
-
-rule write_de_params:
-    output:
-        de_params="de_analysis/de_params.tsv",
-    log:
-        "logs/de_params.log",
-    conda:
-        "envs/env.yml"
-    script:
-        "../scripts/de_params.py"
-
 
 rule de_analysis:
     input:
-        de_params="de_analysis/de_params.tsv",
         all_counts=expand("counts/{sample}_salmon/quant.sf", sample=samples["sample"]),
     output:
         dispersion_graph="de_analysis/dispersion_graph.svg",

--- a/workflow/rules/diffexp.smk
+++ b/workflow/rules/diffexp.smk
@@ -18,6 +18,6 @@ rule de_analysis:
         "logs/de_analysis.log",
     threads: 4
     conda:
-        "envs/env.yml"
+        "../envs/env.yml"
     script:
         "../scripts/de_analysis.py"

--- a/workflow/rules/quantification.smk
+++ b/workflow/rules/quantification.smk
@@ -18,14 +18,14 @@ rule count_reads:
         """
         salmon --no-version-check quant --ont -p {resources.cpus_per_task} \
         -t {input.trs} -l {params.libtype} -a {input.bam} -o {output.tsv} 2> {log}
-    """
+        """
 
 
 rule merge_counts:
     input:
         count_tsvs=expand("counts/{sample}_salmon/quant.sf", sample=samples["sample"]),
     output:
-        "merged/all_counts.tsv",
+        temp("merged/all_counts.tsv"),
     log:
         "logs/merge_count.log",
     conda:


### PR DESCRIPTION
apparentyl due to a rebase mistake: the rule `write_de_params` is not needed anymore and along with all references has been removed.