### PR TITLE
feat: temporary output

### DIFF
--- a/workflow/rules/alignment.smk
+++ b/workflow/rules/alignment.smk
@@ -2,7 +2,7 @@ rule build_minimap_index:  ## build minimap2 index
     input:
         target="transcriptome/transcriptome.fa",
     output:
-        index="index/transcriptome_index.mmi",
+        index=temp("index/transcriptome_index.mmi"),
     params:
         extra=config["minimap_index_opts"],
     log:
@@ -17,7 +17,7 @@ rule map_reads:
         target="index/transcriptome_index.mmi",
         query="filter/{sample}_filtered.fq",
     output:
-        "alignments/{sample}.sam",
+        temp("alignments/{sample}.sam"),
     log:
         "logs/minimap2/mapping_{sample}.log",
     params:

--- a/workflow/rules/alignmod.smk
+++ b/workflow/rules/alignmod.smk
@@ -2,7 +2,7 @@ rule sam_view:
     input:
         sam="alignments/{sample}.sam",
     output:
-        "sorted_alignments/{sample}.bam",
+        temp("sorted_alignments/{sample}.bam"),
     log:
         "logs/samtools/samview_{sample}.log",
     params:
@@ -15,7 +15,7 @@ rule sam_sort:
     input:
         sam="alignments/{sample}.sam",
     output:
-        "sorted_alignments/{sample}_sorted.bam",
+        temp("sorted_alignments/{sample}_sorted.bam"),
     log:
         "logs/samtools/samsort_{sample}.log",
     params:

--- a/workflow/rules/datamod.smk
+++ b/workflow/rules/datamod.smk
@@ -7,7 +7,7 @@ rule genome_to_transcriptome:
         genome="references/genomic.fa",
         annotation="references/genomic.gff",
     output:
-        transcriptome="transcriptome/transcriptome.fa",
+        transcriptome=temp("transcriptome/transcriptome.fa"),
     log:
         "logs/gffread.log",
     conda:
@@ -24,7 +24,7 @@ rule filter_reads:
             samples["sample"][wildcards.sample]
         ),
     output:
-        "filter/{sample}_filtered.fq",
+        temp("filter/{sample}_filtered.fq"),
     message:
         f"Filtering with read length >= {config['min_length']}."
     log:

--- a/workflow/rules/qc.smk
+++ b/workflow/rules/qc.smk
@@ -23,7 +23,7 @@ rule plot_samples:
             caption="../report/nanoplot_sample_report.rst",
         ),
     params:
-        outdir=lambda wildcards: f"NanoPlot/{wildcards.sample}",
+        outdir=temp(lambda wildcards: f"NanoPlot/{wildcards.sample}"),
     log:
         "logs/NanoPlot/{sample}.log",
     resources:
@@ -46,7 +46,7 @@ rule plot_all_samples:
         ),
     # This parameter is in line with the Snakemake docs 8.20.3 guideline on how to avoid having parameters as output prefixes
     params:
-        outdir=lambda wildcards, output: output[0][:-21],
+        outdir=temp(lambda wildcards, output: output[0][:-21]),
     log:
         "logs/NanoPlot/all_samples.log",
     conda:
@@ -86,7 +86,7 @@ rule map_qc:
     input:
         bam="sorted_alignments/{sample}_sorted.bam",
     output:
-        directory("QC/qualimap/{sample}"),
+        temp(directory("QC/qualimap/{sample}")),
     log:
         "logs/qualimap/{sample}.log",
     wrapper:

--- a/workflow/rules/quantification.smk
+++ b/workflow/rules/quantification.smk
@@ -7,9 +7,9 @@ rule count_reads:
         bam="sorted_alignments/{sample}.bam",
         trs="transcriptome/transcriptome.fa",
     output:
-        tsv="counts/{sample}_salmon/quant.sf",
+        tsv=temp("counts/{sample}_salmon/quant.sf"),
     params:
-        outdir=lambda wildcards: f"counts/{wildcards.sample}_salmon",
+        outdir=temp(lambda wildcards: f"counts/{wildcards.sample}_salmon"),
         libtype=config["salmon_libtype"],
     log:
         "logs/salmon/{sample}.log",

--- a/workflow/rules/ref.smk
+++ b/workflow/rules/ref.smk
@@ -24,7 +24,7 @@ rule extract_genome:
     input:
         rules.get_genome.output,
     output:
-        "references/genomic.fa",
+        temp("references/genomic.fa"),
     group:
         "reference"
     params:
@@ -43,7 +43,7 @@ rule extract_annotation:
     input:
         rules.get_genome.output,
     output:
-        "references/genomic.gff",
+        temp("references/genomic.gff"),
     group:
         "reference"
     params:


### PR DESCRIPTION
This works for most output files. 
Some rules that use params to define output directories leave additional files (salmon and NanoPlot). Other rules create additional non-temporary files that remain (gffread). 