### PR TITLE
refactor: remove temp output for testing

### DIFF
--- a/workflow/rules/alignment.smk
+++ b/workflow/rules/alignment.smk
@@ -17,7 +17,7 @@ rule map_reads:
         target="index/transcriptome_index.mmi",
         query="filter/{sample}_filtered.fq",
     output:
-       "alignments/{sample}.sam",
+        "alignments/{sample}.sam",
     log:
         "logs/minimap2/mapping_{sample}.log",
     params:

--- a/workflow/rules/alignment.smk
+++ b/workflow/rules/alignment.smk
@@ -2,7 +2,7 @@ rule build_minimap_index:  ## build minimap2 index
     input:
         target="transcriptome/transcriptome.fa",
     output:
-        index=temp("index/transcriptome_index.mmi"),
+        index="index/transcriptome_index.mmi",
     params:
         extra=config["minimap_index_opts"],
     log:
@@ -17,7 +17,7 @@ rule map_reads:
         target="index/transcriptome_index.mmi",
         query="filter/{sample}_filtered.fq",
     output:
-        temp("alignments/{sample}.sam"),
+       "alignments/{sample}.sam",
     log:
         "logs/minimap2/mapping_{sample}.log",
     params:

--- a/workflow/rules/alignmod.smk
+++ b/workflow/rules/alignmod.smk
@@ -2,7 +2,7 @@ rule sam_view:
     input:
         sam="alignments/{sample}.sam",
     output:
-        temp("sorted_alignments/{sample}.bam"),
+       "sorted_alignments/{sample}.bam",
     log:
         "logs/samtools/samview_{sample}.log",
     params:
@@ -15,7 +15,7 @@ rule sam_sort:
     input:
         sam="alignments/{sample}.sam",
     output:
-        temp("sorted_alignments/{sample}_sorted.bam"),
+        "sorted_alignments/{sample}_sorted.bam,
     log:
         "logs/samtools/samsort_{sample}.log",
     params:

--- a/workflow/rules/alignmod.smk
+++ b/workflow/rules/alignmod.smk
@@ -2,7 +2,7 @@ rule sam_view:
     input:
         sam="alignments/{sample}.sam",
     output:
-       "sorted_alignments/{sample}.bam",
+        "sorted_alignments/{sample}.bam",
     log:
         "logs/samtools/samview_{sample}.log",
     params:
@@ -15,7 +15,7 @@ rule sam_sort:
     input:
         sam="alignments/{sample}.sam",
     output:
-        "sorted_alignments/{sample}_sorted.bam,
+        "sorted_alignments/{sample}_sorted.bam",
     log:
         "logs/samtools/samsort_{sample}.log",
     params:

--- a/workflow/rules/datamod.smk
+++ b/workflow/rules/datamod.smk
@@ -7,7 +7,7 @@ rule genome_to_transcriptome:
         genome="references/genomic.fa",
         annotation="references/genomic.gff",
     output:
-        transcriptome=temp("transcriptome/transcriptome.fa"),
+        transcriptome="transcriptome/transcriptome.fa",
     log:
         "logs/gffread.log",
     conda:
@@ -24,7 +24,7 @@ rule filter_reads:
             samples["sample"][wildcards.sample]
         ),
     output:
-        temp("filter/{sample}_filtered.fq"),
+        "filter/{sample}_filtered.fq",
     message:
         f"Filtering with read length >= {config['min_length']}."
     log:

--- a/workflow/rules/qc.smk
+++ b/workflow/rules/qc.smk
@@ -23,7 +23,7 @@ rule plot_samples:
             caption="../report/nanoplot_sample_report.rst",
         ),
     params:
-        outdir=temp(lambda wildcards: f"NanoPlot/{wildcards.sample}"),
+        outdir=lambda wildcards: f"NanoPlot/{wildcards.sample}",
     log:
         "logs/NanoPlot/{sample}.log",
     resources:
@@ -46,7 +46,7 @@ rule plot_all_samples:
         ),
     # This parameter is in line with the Snakemake docs 8.20.3 guideline on how to avoid having parameters as output prefixes
     params:
-        outdir=temp(lambda wildcards, output: output[0][:-21]),
+        outdir=lambda wildcards, output: output[0][:-21],
     log:
         "logs/NanoPlot/all_samples.log",
     conda:
@@ -86,7 +86,7 @@ rule map_qc:
     input:
         bam="sorted_alignments/{sample}_sorted.bam",
     output:
-        temp(directory("QC/qualimap/{sample}")),
+        directory("QC/qualimap/{sample}"),
     log:
         "logs/qualimap/{sample}.log",
     wrapper:

--- a/workflow/rules/quantification.smk
+++ b/workflow/rules/quantification.smk
@@ -9,7 +9,7 @@ rule count_reads:
     output:
         tsv="counts/{sample}_salmon/quant.sf",
     params:
-        outdir=temp(lambda wildcards: f"counts/{wildcards.sample}_salmon"),
+        outdir=lambda wildcards: f"counts/{wildcards.sample}_salmon",
         libtype=config["salmon_libtype"],
     log:
         "logs/salmon/{sample}.log",

--- a/workflow/rules/quantification.smk
+++ b/workflow/rules/quantification.smk
@@ -7,7 +7,7 @@ rule count_reads:
         bam="sorted_alignments/{sample}.bam",
         trs="transcriptome/transcriptome.fa",
     output:
-        tsv=temp("counts/{sample}_salmon/quant.sf"),
+        tsv="counts/{sample}_salmon/quant.sf",
     params:
         outdir=temp(lambda wildcards: f"counts/{wildcards.sample}_salmon"),
         libtype=config["salmon_libtype"],
@@ -26,7 +26,7 @@ rule merge_counts:
     input:
         count_tsvs=expand("counts/{sample}_salmon/quant.sf", sample=samples["sample"]),
     output:
-        temp("merged/all_counts.tsv"),
+        "merged/all_counts.tsv",
     log:
         "logs/merge_count.log",
     conda:

--- a/workflow/rules/ref.smk
+++ b/workflow/rules/ref.smk
@@ -24,7 +24,7 @@ rule extract_genome:
     input:
         rules.get_genome.output,
     output:
-        temp("references/genomic.fa"),
+        "references/genomic.fa",
     group:
         "reference"
     params:
@@ -43,7 +43,7 @@ rule extract_annotation:
     input:
         rules.get_genome.output,
     output:
-        temp("references/genomic.gff"),
+        "references/genomic.gff",
     group:
         "reference"
     params:


### PR DESCRIPTION
Removed temporary output files to keep intermediate results which makes teting new tools easier.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Output paths for various rules have been updated to treat files as permanent outputs instead of temporary, enhancing file management and accessibility.
	- Specific rules affected include `build_minimap_index`, `map_reads`, `sam_view`, `sam_sort`, `genome_to_transcriptome`, `filter_reads`, `plot_samples`, `plot_all_samples`, `map_qc`, `count_reads`, `merge_counts`, `extract_genome`, and `extract_annotation`.

- **Bug Fixes**
	- Improved handling of output directories to ensure files are retained after workflow execution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->