### PR TITLE
feat: qm report

### DIFF
--- a/.test/config-simple/config.yml
+++ b/.test/config-simple/config.yml
@@ -39,10 +39,10 @@ maximum_secondary: 100
 secondary_score_ratio: 1.0
 
 # Samtools view opts, "-b" creates BAM from SAM.
-sview_opts: "-b"
+samtobam_opts: "-b"
 
 # Samtools sort opts,
-ssort_opts: ""
+bamsort_opts: ""
 
 # Salmon library type
 salmon_libtype: "U"
@@ -51,7 +51,7 @@ salmon_libtype: "U"
 # QC options
 
 # Samtools stats opts
-sstats_opts: ""
+bamstats_opts: ""
 
 # Count filtering options - customize these according to your experimental design:
 

--- a/config/Mainz-MogonNHR/config.yml
+++ b/config/Mainz-MogonNHR/config.yml
@@ -37,10 +37,10 @@ maximum_secondary: 100
 secondary_score_ratio: 1.0
 
 # Samtools view opts, "-b" creates BAM from SAM.
-sview_opts: "-b"
+samtobam_opts: "-b"
 
 # Samtools sort opts,
-ssort_opts: ""
+bsort_opts: ""
 
 # Salmon library type
 salmon_libtype: "U"
@@ -49,7 +49,7 @@ salmon_libtype: "U"
 # QC options
 
 # Samtools stats opts
-sstats_opts: ""
+bstats_opts: ""
 
 # Count filtering options - customize these according to your experimental design:
 

--- a/config/Mainz-MogonNHR/config.yml
+++ b/config/Mainz-MogonNHR/config.yml
@@ -40,7 +40,7 @@ secondary_score_ratio: 1.0
 samtobam_opts: "-b"
 
 # Samtools sort opts,
-bsort_opts: ""
+bamsort_opts: ""
 
 # Salmon library type
 salmon_libtype: "U"
@@ -49,7 +49,7 @@ salmon_libtype: "U"
 # QC options
 
 # Samtools stats opts
-bstats_opts: ""
+bamstats_opts: ""
 
 # Count filtering options - customize these according to your experimental design:
 
@@ -71,7 +71,7 @@ design_factors:
   - "condition"
 #
 # The (log2) log fold change under the null hypothesis. (default: 0).
-lfc_null: 0.1
+lfc_null: 1
 #
 # The alternative hypothesis for computing wald p-values. By default,
 # the normal Wald test assesses deviation of the estimated log fold

--- a/workflow/profile/Mainz-MogonNHR/config.yaml
+++ b/workflow/profile/Mainz-MogonNHR/config.yaml
@@ -39,22 +39,22 @@ set-resources:
         mem_mb_per_cpu: 1800
         runtime: "1h"
 
-    sam_sort:
+    bam_sort:
         cpus_per_task: 4
         mem_mb_per_cpu: 7200
         runtime: "2h"
 
-    sam_view:
+    sam_to_bam:
         cpus_per_task: 1
         mem_mb_per_cpu: 1800
         runtime: "1h"
 
-    sam_index:
+    bam_index:
         cpus_per_task: 8
         mem_mb_per_cpu: 1800
         runtime: "30m"
 
-    sam_stats:
+    bam_stats:
         cpus_per_task: 8
         mem_mb_per_cpu: 1800
         runtime: "30m"

--- a/workflow/report/nanoplot_all_samples_report.rst
+++ b/workflow/report/nanoplot_all_samples_report.rst
@@ -1,1 +1,1 @@
-Full `NanoPlot, <https://github.com/wdecoster/NanoPlot>`_ sequencing quality report for total samples .
+Full `NanoPlot, <https://github.com/wdecoster/NanoPlot>`_ sequencing quality report for total samples.

--- a/workflow/report/qualimap.rst
+++ b/workflow/report/qualimap.rst
@@ -1,0 +1,1 @@
+Full `QualiMap, <http://qualimap.conesalab.org/doc_html/analysis.html#bam-qc>`_ BAMQC alignment quality report for total samples.

--- a/workflow/rules/alignmod.smk
+++ b/workflow/rules/alignmod.smk
@@ -4,9 +4,9 @@ rule sam_to_bam:
     output:
         "alignments/{sample}.bam",
     log:
-        "logs/samtools/samview_{sample}.log",
+        "logs/samtools/samtobam_{sample}.log",
     params:
-        extra=f'{config["sview_opts"]}',
+        extra=f'{config["samtobam_opts"]}',
     wrapper:
         "v3.13.4/bio/samtools/view"
 
@@ -17,8 +17,8 @@ rule bam_sort:
     output:
         "sorted_alignments/{sample}_sorted.bam",
     log:
-        "logs/samtools/samsort_{sample}.log",
+        "logs/samtools/bamsort_{sample}.log",
     params:
-        extra=f'{config["ssort_opts"]}',
+        extra=f'{config["bsort_opts"]}',
     wrapper:
         "v3.13.4/bio/samtools/sort"

--- a/workflow/rules/alignmod.smk
+++ b/workflow/rules/alignmod.smk
@@ -19,6 +19,6 @@ rule bam_sort:
     log:
         "logs/samtools/bamsort_{sample}.log",
     params:
-        extra=f'{config["bsort_opts"]}',
+        extra=f'{config["bamsort_opts"]}',
     wrapper:
         "v3.13.4/bio/samtools/sort"

--- a/workflow/rules/alignmod.smk
+++ b/workflow/rules/alignmod.smk
@@ -1,8 +1,8 @@
-rule sam_view:
+rule sam_to_bam:
     input:
         sam="alignments/{sample}.sam",
     output:
-        "sorted_alignments/{sample}.bam",
+        "alignments/{sample}.bam",
     log:
         "logs/samtools/samview_{sample}.log",
     params:
@@ -11,9 +11,9 @@ rule sam_view:
         "v3.13.4/bio/samtools/view"
 
 
-rule sam_sort:
+rule bam_sort:
     input:
-        sam="alignments/{sample}.sam",
+        bam="alignments/{sample}.bam",
     output:
         "sorted_alignments/{sample}_sorted.bam",
     log:

--- a/workflow/rules/commons.smk
+++ b/workflow/rules/commons.smk
@@ -65,10 +65,10 @@ def aggregate_input(samples):
 def rule_all_input():
     all_input = list()
     all_input.append("versions.txt")
-    all_input.extend(expand("QC/NanoPlot/{sample}.tar.gz", sample=samples["sample"]))
-    all_input.append("QC/NanoPlot/all_samples.tar.gz")
+    all_input.extend(expand("NanoPlot/{sample}/NanoPlot-report.html", sample=samples["sample"]))
+    all_input.append("NanoPlot/all_samples/NanoPlot-report.html")
     all_input.extend(expand("QC/samstats/{sample}.txt", sample=samples["sample"]))
-    all_input.extend(expand("QC/qualimap/{sample}.tar.gz", sample=samples["sample"]))
+    all_input.extend(expand("qualimap/{sample}/qualimapReport.html", sample=samples["sample"]))
     all_input.extend(
         expand("counts/{sample}_salmon/quant.sf", sample=samples["sample"])
     )

--- a/workflow/rules/commons.smk
+++ b/workflow/rules/commons.smk
@@ -65,10 +65,14 @@ def aggregate_input(samples):
 def rule_all_input():
     all_input = list()
     all_input.append("versions.txt")
-    all_input.extend(expand("NanoPlot/{sample}/NanoPlot-report.html", sample=samples["sample"]))
+    all_input.extend(
+        expand("NanoPlot/{sample}/NanoPlot-report.html", sample=samples["sample"])
+    )
     all_input.append("NanoPlot/all_samples/NanoPlot-report.html")
     all_input.extend(expand("QC/samstats/{sample}.txt", sample=samples["sample"]))
-    all_input.extend(expand("qualimap/{sample}/qualimapReport.html", sample=samples["sample"]))
+    all_input.extend(
+        expand("qualimap/{sample}/qualimapReport.html", sample=samples["sample"])
+    )
     all_input.extend(
         expand("counts/{sample}_salmon/quant.sf", sample=samples["sample"])
     )

--- a/workflow/rules/commons.smk
+++ b/workflow/rules/commons.smk
@@ -69,7 +69,7 @@ def rule_all_input():
         expand("NanoPlot/{sample}/NanoPlot-report.html", sample=samples["sample"])
     )
     all_input.append("NanoPlot/all_samples/NanoPlot-report.html")
-    all_input.extend(expand("QC/samstats/{sample}.txt", sample=samples["sample"]))
+    all_input.extend(expand("QC/bamstats/{sample}.txt", sample=samples["sample"]))
     all_input.extend(
         expand("qualimap/{sample}/qualimapReport.html", sample=samples["sample"])
     )

--- a/workflow/rules/diffexp.smk
+++ b/workflow/rules/diffexp.smk
@@ -15,7 +15,7 @@ rule de_analysis:
             category="Results",
             caption="../report/ma_graph.rst",
             labels={
-                "figure": "Bland-Altman plot",
+                "figure": "MA plot",
             },
         ),
         de_heatmap=report(
@@ -23,7 +23,7 @@ rule de_analysis:
             category="Results",
             caption="../report/heatmap.rst",
             labels={
-                "figure": "Heatmap",
+                "figure": "Gene heatmap",
             },
         ),
         correlation_matrix=report(
@@ -40,7 +40,7 @@ rule de_analysis:
             category="Results",
             caption="../report/heatmap_top.rst",
             labels={
-                "figure": "Top heatmap",
+                "figure": "Top gene heatmap",
             },
         ),
         lfc_analysis="de_analysis/lfc_analysis.csv",

--- a/workflow/rules/diffexp.smk
+++ b/workflow/rules/diffexp.smk
@@ -6,33 +6,51 @@ rule de_analysis:
             "de_analysis/dispersion_graph.svg",
             category="Results",
             caption="../report/dispersion_graph.rst",
+            labels={
+                "figure": "Dispersion graph",
+            },
         ),
         ma_graph=report(
             "de_analysis/ma_graph.svg",
             category="Results",
             caption="../report/ma_graph.rst",
+            labels={
+                "figure": "Bland-Altman plot",
+            },
         ),
         de_heatmap=report(
             "de_analysis/heatmap.svg",
             category="Results",
             caption="../report/heatmap.rst",
+            labels={
+                "figure": "Heatmap",
+            },
         ),
         correlation_matrix=report(
             "de_analysis/correlation_matrix.svg",
             category="Results",
             caption="../report/correlation_matrix.rst",
+            labels={
+                "figure": "Correlation matrix",
+            },
         ),
         normalized_counts="de_analysis/normalized_counts.csv",
         de_top_heatmap=report(
             "de_analysis/heatmap_top.svg",
             category="Results",
             caption="../report/heatmap_top.rst",
+            labels={
+                "figure": "Top heatmap",
+            },
         ),
         lfc_analysis="de_analysis/lfc_analysis.csv",
         volcano_plot=report(
             "de_analysis/volcano_plot.svg",
             category="Results",
             caption="../report/volcano_plot.rst",
+            labels={
+                "figure": "Volcano plot",
+            },
         ),
     params:
         samples=samples,

--- a/workflow/rules/qc.smk
+++ b/workflow/rules/qc.smk
@@ -102,10 +102,10 @@ rule bam_stats:
     input:
         bam="alignments/{sample}.bam",
     output:
-        "QC/samstats/{sample}.txt",
+        "QC/bamstats/{sample}.txt",
     log:
         "logs/samtools/bamstats_{sample}.log",
     params:
-        extra=f'{config["bamstats_opts"]}',
+        extra=config["bamstats_opts"],
     wrapper:
         "v3.13.4/bio/samtools/stats"

--- a/workflow/rules/qc.smk
+++ b/workflow/rules/qc.smk
@@ -2,9 +2,6 @@ import os
 
 
 localrules:
-    compress_nplot,
-    compress_nplot_all,
-    compress_map_qc,
     qm_report,
 
 

--- a/workflow/rules/qc.smk
+++ b/workflow/rules/qc.smk
@@ -57,32 +57,6 @@ rule plot_all_samples:
         "--fastq {input} --outdir {params.outdir} 2> {log}"
 
 
-rule compress_nplot:
-    input:
-        samples=rules.plot_samples.output,
-    output:
-        "QC/NanoPlot/{sample}.tar.gz",
-    log:
-        "logs/NanoPlot/compress_{sample}.log",
-    conda:
-        "../envs/base.yml"
-    script:
-        "../scripts/make_archive.py"
-
-
-rule compress_nplot_all:
-    input:
-        all_samples=rules.plot_all_samples.output,
-    output:
-        "QC/NanoPlot/all_samples.tar.gz",
-    log:
-        "logs/NanoPlot/compress_all_samples.log",
-    conda:
-        "../envs/base.yml"
-    script:
-        "../scripts/make_archive.py"
-
-
 rule map_qc:
     input:
         bam="sorted_alignments/{sample}_sorted.bam",
@@ -92,19 +66,6 @@ rule map_qc:
         "logs/qualimap/{sample}.log",
     wrapper:
         "v4.4.0/bio/qualimap/bamqc"
-
-
-rule compress_map_qc:
-    input:
-        map_qc=rules.map_qc.output,
-    output:
-        "QC/qualimap/{sample}.tar.gz",
-    log:
-        "logs/qualimap/compress_{sample}.log",
-    conda:
-        "../envs/base.yml"
-    script:
-        "../scripts/make_archive.py"
 
 
 # this is a dummy rule to create input for the report because the QualiMap wrapper only accepts directories as valid output

--- a/workflow/rules/qc.smk
+++ b/workflow/rules/qc.smk
@@ -106,6 +106,23 @@ rule compress_map_qc:
         "../scripts/make_archive.py"
 
 
+rule qm_report:
+    input:
+        map_qc=rules.map_qc.output,
+    output:
+        qm_report=report(
+            "QC/qualimap/{sample}/qualimapReport.html",
+            category="Quality control",
+            caption="../report/qualimap.rst",
+        ),
+    log:
+        "logs/qualimap/{sample}_report.log",
+    conda:
+        "../envs/base.yml"
+    shell:
+        "ls 2> {log}"
+
+
 rule sam_stats:
     input:
         bam="sorted_alignments/{sample}.bam",

--- a/workflow/rules/qc.smk
+++ b/workflow/rules/qc.smk
@@ -106,6 +106,6 @@ rule bam_stats:
     log:
         "logs/samtools/bamstats_{sample}.log",
     params:
-        extra=f'{config["bstats_opts"]}',
+        extra=f'{config["bamstats_opts"]}',
     wrapper:
         "v3.13.4/bio/samtools/stats"

--- a/workflow/rules/qc.smk
+++ b/workflow/rules/qc.smk
@@ -18,7 +18,12 @@ rule plot_samples:
         scatter=report(
             "NanoPlot/{sample}/NanoPlot-report.html",
             category="Quality control",
+            subcategory="NanoPlot",
             caption="../report/nanoplot_sample_report.rst",
+            labels={
+                "model": "NanoPlot",
+                "figure": "{sample}",
+            },
         ),
     params:
         outdir=lambda wildcards: f"NanoPlot/{wildcards.sample}",
@@ -40,7 +45,12 @@ rule plot_all_samples:
         scatter=report(
             "NanoPlot/all_samples/NanoPlot-report.html",
             category="Quality control",
+            subcategory="NanoPlot",
             caption="../report/nanoplot_all_samples_report.rst",
+            labels={
+                "model": "NanoPlot",
+                "figure": "All samples",
+            },
         ),
     # This parameter is in line with the Snakemake docs 8.20.3 guideline on how to avoid having parameters as output prefixes
     params:
@@ -73,7 +83,12 @@ rule qm_report:
         qm_report=report(
             "qualimap/{sample}/qualimapReport.html",
             category="Quality control",
+            subcategory="QualiMap",
             caption="../report/qualimap.rst",
+            labels={
+                "model": "QualiMap",
+                "figure": "{sample}",
+            },
         ),
     log:
         "logs/qualimap/{sample}_report.log",
@@ -89,8 +104,8 @@ rule bam_stats:
     output:
         "QC/samstats/{sample}.txt",
     log:
-        "logs/samtools/samstats_{sample}.log",
+        "logs/samtools/bamstats_{sample}.log",
     params:
-        extra=f'{config["sstats_opts"]}',
+        extra=f'{config["bstats_opts"]}',
     wrapper:
         "v3.13.4/bio/samtools/stats"

--- a/workflow/rules/qc.smk
+++ b/workflow/rules/qc.smk
@@ -5,6 +5,7 @@ localrules:
     compress_nplot,
     compress_nplot_all,
     compress_map_qc,
+    qm_report,
 
 
 configfile: "config/config.yml"
@@ -106,12 +107,13 @@ rule compress_map_qc:
         "../scripts/make_archive.py"
 
 
+# this is a dummy rule to create input for the report because the QualiMap wrapper only accepts directories as valid output
 rule qm_report:
     input:
         map_qc=rules.map_qc.output,
     output:
         qm_report=report(
-            "QC/qualimap/{sample}/qualimapReport.html",
+            "qualimap/{sample}/qualimapReport.html",
             category="Quality control",
             caption="../report/qualimap.rst",
         ),
@@ -120,7 +122,7 @@ rule qm_report:
     conda:
         "../envs/base.yml"
     shell:
-        "ls 2> {log}"
+        "cp -a QC/qualimap/{wildcards.sample} qualimap/ 2> {log}"
 
 
 rule sam_stats:

--- a/workflow/rules/qc.smk
+++ b/workflow/rules/qc.smk
@@ -86,9 +86,9 @@ rule qm_report:
         "cp -a QC/qualimap/{wildcards.sample} qualimap/ 2> {log}"
 
 
-rule sam_stats:
+rule bam_stats:
     input:
-        bam="sorted_alignments/{sample}.bam",
+        bam="alignments/{sample}.bam",
     output:
         "QC/samstats/{sample}.txt",
     log:

--- a/workflow/rules/quantification.smk
+++ b/workflow/rules/quantification.smk
@@ -4,7 +4,7 @@ localrules:
 
 rule count_reads:
     input:
-        bam="sorted_alignments/{sample}.bam",
+        bam="alignments/{sample}.bam",
         trs="transcriptome/transcriptome.fa",
     output:
         tsv="counts/{sample}_salmon/quant.sf",


### PR DESCRIPTION
Included QualiMap report in Snakemake report. However, since the QualiMap report gets its plots from its directory, they can not be displayed within the Snakemake report at the moment.
Refactored unnecessary compress rules.
Renamed rules to better reflect their function.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a new rule `qm_report` for generating QualiMap output reports.
	- Updated workflow parameters for BAM file processing, enhancing clarity and consistency.

- **Bug Fixes**
	- Corrected repository URL in configuration settings.

- **Documentation**
	- Added a hyperlink to QualiMap documentation in the report file.
	- Minor text correction in the NanoPlot report documentation.

- **Refactor**
	- Renamed several workflow tasks to reflect BAM processing.
	- Consolidated quality control reporting functionalities.
	- Updated input paths and parameters for BAM file handling across multiple rules.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->