### PR TITLE
feat: parallel splice alignment

### DIFF
--- a/config/Ch_rip_male_v_female/config.yml
+++ b/config/Ch_rip_male_v_female/config.yml
@@ -107,6 +107,10 @@ deseq2:
 isoform_analysis:
     # Enables FLAIR Isoform Analysis if 'true'
     FLAIR: true
+    #
+    minfragsize: 80
+    #
+    maxintronlen: "200k"
     # Minimum MAPQ of read assignment to an isoform (default 1).
     qscore: 1
     # min read count expression threshold. Isoforms which contain fewer than 'exp_thresh' (Default=10) reads in both conditions are filtered out.

--- a/workflow/profile/Mainz-MogonNHR/config.yaml
+++ b/workflow/profile/Mainz-MogonNHR/config.yaml
@@ -13,6 +13,8 @@ set-resources:
     map_reads:
         runtime: "3h"
         slurm_partition: "smallcpu" # needs benchmarking
+    splice_align:
+        runtime: "3h"
     plot_samples:
         runtime: "3h"
     plot_all_samples:
@@ -22,7 +24,12 @@ set-resources:
     bam_sort:
         mem_mb_per_cpu: 7200
         runtime: "2h"
+    splice_bam_sort:
+        mem_mb_per_cpu: 7200
+        runtime: "2h"
     sam_to_bam:
+        runtime: "90m"
+    splice_sam_to_bam:
         runtime: "90m"
     count_reads:
         runtime: "1h"
@@ -33,6 +40,8 @@ set-resources:
     build_flair_genome_index:
         cpus_per_task: 4
         mem_mb_per_cpu: 3600
+    create_splice_beds:
+        runtime: "2h"
     flair_align:
         cpus_per_task: 32
         mem_mb_per_cpu: 2500
@@ -56,11 +65,14 @@ set-resources:
 set-threads:
     build_minimap_index: 4
     map_reads: 32
+    splice_align: 32
     plot_samples: 4
     plot_all_samples: 8
     map_qc: 8
     bam_sort: 4
+    splice_bam_sort: 4
     bam_index: 8
+    splice_bam_index: 8
     bam_stats: 8
     count_reads: 8
     de_analysis: 8

--- a/workflow/scripts/create_splice_bed.py
+++ b/workflow/scripts/create_splice_bed.py
@@ -1,0 +1,141 @@
+import os
+import sys
+import pysam
+
+sys.stderr = sys.stdout = open(snakemake.log[0], "wt")
+
+os.environ["OPENBLAS_NUM_THREADS"] = "1"
+
+
+def inferMM2JuncStrand(read):
+    orientation = read.flag
+    try:
+        juncDir = read.get_tag("ts")
+    except KeyError:
+        juncDir = None
+
+    if not juncDir:
+        left, right = read.cigar[0], read.cigar[-1]
+        s1, s2 = read.seq[:50], read.seq[-50:]
+        if ("T" * 10 in s1 and left[0] == 4 and left[1] >= 10) and (
+            "A" * 10 in s2 and right[0] == 4 and right[1] >= 10
+        ):
+            juncDir = "ambig"
+        elif "T" * 10 in s1 and left[0] == 4 and left[1] >= 10:
+            juncDir = "-" if orientation == 16 else "+"
+        elif "A" * 10 in s2 and right[0] == 4 and right[1] >= 10:
+            juncDir = "+" if orientation == 16 else "-"
+        else:
+            juncDir = "ambig"
+
+    else:
+        if orientation == 0 and juncDir == "+":
+            juncDir = "+"
+        elif orientation == 0 and juncDir == "-":
+            juncDir = "-"
+        elif orientation == 16 and juncDir == "+":
+            juncDir = "-"
+        elif orientation == 16 and juncDir == "-":
+            juncDir = "+"
+
+    return juncDir
+
+
+def bed_from_cigar(
+    alignstart,
+    is_reverse,
+    cigartuples,
+    readname,
+    referencename,
+    qualscore,
+    juncDirection,
+):
+    positiveTxn = "27,158,119"
+    negativeTxn = "217,95,2"
+    unknownTxn = "99,99,99"
+    refpos = alignstart
+    intronblocks = []
+    hasmatch = False
+
+    for block in cigartuples:
+        if block[0] == 3 and hasmatch:
+            intronblocks.append([refpos, refpos + block[1]])
+            refpos += block[1]
+        elif block[0] in {0, 7, 8, 2}:
+            refpos += block[1]
+            if block[0] in {0, 7, 8}:
+                hasmatch = True
+
+    esizes, estarts = [], [0]
+    for i in intronblocks:
+        esizes.append(i[0] - (alignstart + estarts[-1]))
+        estarts.append(i[1] - alignstart)
+    esizes.append(refpos - (alignstart + estarts[-1]))
+
+    rgbcolor = {"+": positiveTxn, "-": negativeTxn, "ambig": unknownTxn}.get(
+        juncDirection, unknownTxn
+    )
+
+    return [
+        referencename,
+        str(alignstart),
+        str(refpos),
+        readname,
+        str(qualscore),
+        juncDirection,
+        str(alignstart),
+        str(refpos),
+        rgbcolor,
+        str(len(intronblocks) + 1),
+        ",".join([str(x) for x in esizes]) + ",",
+        ",".join([str(x) for x in estarts]) + ",",
+    ]
+
+
+def filter_bam(input_bam, output_bam, output_bed, output_sup, output_trash):
+    with pysam.AlignmentFile(input_bam, "rb") as samfile, pysam.AlignmentFile(
+        output_bam, "wb", template=samfile
+    ) as filtered_bam, pysam.AlignmentFile(
+        output_sup, "wb", template=samfile
+    ) as sup_bam, pysam.AlignmentFile(
+        output_trash, "wb", template=samfile
+    ) as trash_bam, open(
+        output_bed, "w"
+    ) as bed_out:
+        for read in samfile.fetch():
+            if not read.is_mapped or read.is_secondary:
+                trash_bam.write(read)
+                continue
+
+            if read.has_tag("SA") or read.is_supplementary:
+                sup_bam.write(read)
+                continue
+
+            if read.mapping_quality > 1:
+                juncstrand = inferMM2JuncStrand(read)
+                bedline = bed_from_cigar(
+                    read.reference_start,
+                    read.is_reverse,
+                    read.cigartuples,
+                    read.query_name,
+                    read.reference_name,
+                    read.mapping_quality,
+                    juncstrand,
+                )
+                bed_out.write("\t".join(bedline) + "\n")
+                filtered_bam.write(read)
+            else:
+                trash_bam.write(read)
+
+    pysam.index(output_bam)
+    pysam.index(output_sup)
+    pysam.index(output_trash)
+
+
+filter_bam(
+    snakemake.input.bam,
+    snakemake.output.flair_bam,
+    snakemake.output.flair_bed,
+    snakemake.output.flair_sup,
+    snakemake.output.flair_trash,
+)


### PR DESCRIPTION
Replaces the 'flair align' module with a custom script and Snakemake rules that allow parallel sample alignment.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced new configuration options that allow users to customize isoform analysis with adjustable fragment size and intron length limits.
  - Expanded resource settings with dedicated runtime and thread allocations to enhance splice alignment operations.
  - Updated the analysis pipeline with refined steps for alignment processing, conversion, sorting, and output generation.
  - Added a new tool for generating splice-oriented BED files to support more efficient downstream analysis.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->