### PR TITLE
chore: updated schema to version 2020-12

### DIFF
--- a/workflow/schemas/config.schema.yaml
+++ b/workflow/schemas/config.schema.yaml
@@ -1,4 +1,4 @@
-$schema: "http://json-schema.org/draft-07/schema#"
+$schema: "https://json-schema.org/draft/2020-12/schema"
 
 description: snakemake configuration file
 type: object


### PR DESCRIPTION
The schema was updated to 2020-12 because [Snakemake 9.6.0 ](https://github.com/snakemake/snakemake/releases/tag/v9.6.0) updated the validator utility.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the configuration schema to use the latest JSON Schema specification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->