### PR TITLE
fix: 10h for flair diff exp - only 1 thread

### DIFF
--- a/workflow/profile/Mainz-MogonNHR/config.yaml
+++ b/workflow/profile/Mainz-MogonNHR/config.yaml
@@ -46,7 +46,7 @@ set-resources:
         runtime: "2h"
     flair_diffexp:
         mem_mb_per_cpu: 5000
-        runtime: "6h"
+        runtime: "10h"
     lambda_gene_annotation:
         mem_mb_per_cpu: 7200
 
@@ -67,5 +67,5 @@ set-threads:
     flair_correct: 8
     flair_collapse: 32
     flair_quantify: 32
-    flair_diffexp: 8
+    flair_diffexp: 1
     lambda_gene_annotation: 32


### PR DESCRIPTION
simple as that, a minor correction for runtime and parallelism in the flair_diffexp rule: the rule takes a long time and apparently does not run in parallel

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Chores
  - Updated Mainz-MogonNHR workflow profile for flair_diffexp:
    - Increased job runtime limit from 6h to 10h.
    - Reduced CPUs per task from 8 to 1.
  - Impact: Jobs will request longer walltime but use a single CPU, which may change execution time characteristics and queue placement. Users may observe different scheduling behavior and overall runtime due to reduced parallelism combined with extended allowed duration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->